### PR TITLE
Add `VolkszaehlerEntitiesClient` for retrieving entity metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Unreleased
+----------
+
+- Add `VolkszaehlerEntitiesClient` for retrieving entity metadata
+
 0.6.0 - 2026-04-07
 ------------------
 

--- a/example.py
+++ b/example.py
@@ -4,7 +4,7 @@ import asyncio
 
 import aiohttp
 
-from volkszaehler import Volkszaehler
+from volkszaehler import Volkszaehler, VolkszaehlerEntitiesClient
 
 HOST = "demo.volkszaehler.org"
 UUID = "57acbef0-88a9-11e4-934f-6b0f9ecd95a8"
@@ -13,6 +13,12 @@ UUID = "57acbef0-88a9-11e4-934f-6b0f9ecd95a8"
 async def main():
     """The main part of the example script."""
     async with aiohttp.ClientSession() as session:
+        entitiesClient = VolkszaehlerEntitiesClient(
+            session, host=HOST, port=443, tls=True
+        )
+        await entitiesClient.get_entities()
+        print("Entity Title:", entitiesClient.entities[0]["title"])
+
         zaehler = Volkszaehler(session, UUID, host=HOST, port=443, tls=True)
 
         # Get the data

--- a/tests/test_volkszaehler.py
+++ b/tests/test_volkszaehler.py
@@ -3,7 +3,7 @@
 import aiohttp
 import pytest
 
-from volkszaehler import Volkszaehler
+from volkszaehler import Volkszaehler, VolkszaehlerEntitiesClient
 from volkszaehler.exceptions import VolkszaehlerApiConnectionError
 
 
@@ -46,7 +46,6 @@ class MockSession:
         }
     ],
 )
-
 @pytest.mark.asyncio
 async def test_get_data_success(mock_json):
     """Test successful data retrieval from Volkszaehler API."""
@@ -76,3 +75,52 @@ async def test_get_data_connection_error():
     v = Volkszaehler(FailingSession(), uuid="abc123")
     with pytest.raises(VolkszaehlerApiConnectionError):
         await v.get_data()
+
+
+@pytest.mark.parametrize(
+    "mock_json",
+    [
+        {
+            "version": "0.3",
+            "entities": [
+                {
+                    "uuid": "57acbef0-88a9-11e4-934f-6b0f9ecd95a8",
+                    "type": "electric meter",
+                    "color": "#c62828",
+                    "fillstyle": 0,
+                    "linestyle": "solid",
+                    "public": True,
+                    "resolution": 1000,
+                    "style": "steps",
+                    "title": "PV Produktion",
+                    "yaxis": "auto",
+                },
+            ],
+        }
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_entities_success(mock_json):
+    """Test successful data retrieval from Volkszaehler entity API."""
+    mock_response = MockResponse(200, mock_json)
+    mock_session = MockSession(mock_response)
+    v = VolkszaehlerEntitiesClient(mock_session)
+    await v.get_entities()
+    assert len(v.entities) == 1
+    assert v.entities[0]["title"] == "PV Produktion"
+
+
+@pytest.mark.asyncio
+async def test_get_entities_connection_error():
+    """Test handling of connection errors when retrieving data from Volkszaehler API."""
+
+    class FailingSession:
+        """A session that simulates a connection error."""
+
+        async def get(self, url, timeout=None):
+            """Simulate a connection error."""
+            raise aiohttp.ClientError()
+
+    v = VolkszaehlerEntitiesClient(FailingSession())
+    with pytest.raises(VolkszaehlerApiConnectionError):
+        await v.get_entities()

--- a/volkszaehler/__init__.py
+++ b/volkszaehler/__init__.py
@@ -6,10 +6,13 @@ import logging
 import aiohttp
 
 from . import exceptions
+from .types import Entity
 
 _LOGGER = logging.getLogger(__name__)
 _RESOURCE = "{schema}://{host}:{port}/middleware.php/data/{uuid}.json"
 _RESOURCE_NO_MIDDLEWARE = "{schema}://{host}:{port}/data/{uuid}.json"
+_RESOURCE_ENTITY = "{schema}://{host}:{port}/middleware.php/entity.json"
+_RESOURCE_ENTITY_NO_MIDDLEWARE = "{schema}://{host}:{port}/entity.json"
 _RESOURCE_FROM = "from={param_from}"
 _RESOURCE_TO = "to={param_to}"
 
@@ -71,3 +74,37 @@ class Volkszaehler(object):
         self.consumption = self.data["data"]["consumption"]
         self.tuples = self.data["data"]["tuples"]
         self.last = self.data["data"]["tuples"][-1][1]
+
+
+class VolkszaehlerEntitiesClient(object):
+    """A class for getting entities."""
+
+    def __init__(self, session, host="localhost", port=80, tls=False, middleware=True):
+        self._session = session
+
+        if middleware:
+            self.url = _RESOURCE_ENTITY.format(
+                schema="https" if tls else "http", host=host, port=port
+            )
+        else:
+            self.url = _RESOURCE_ENTITY_NO_MIDDLEWARE.format(
+                schema="https" if tls else "http", host=host, port=port
+            )
+
+        self.entities: list[Entity] = []
+
+    async def get_entities(self):
+        """Retrieve the entities."""
+        try:
+            timeout = aiohttp.ClientTimeout(total=5)
+            response = await self._session.get(self.url, timeout=timeout)
+
+            _LOGGER.debug("Response from Volkszaehler API: %s", response.status)
+            self.data = await response.json()
+            _LOGGER.debug(self.data)
+        except (asyncio.TimeoutError, aiohttp.ClientError):
+            _LOGGER.error("Can not load entities from Volkszaehler API")
+            self.data = None
+            raise exceptions.VolkszaehlerApiConnectionError()
+
+        self.entities = self.data.get("entities", [])

--- a/volkszaehler/types.py
+++ b/volkszaehler/types.py
@@ -1,0 +1,60 @@
+"""Type definitions for Volkszaehler entities."""
+
+from typing import Literal, TypedDict
+
+# List from https://github.com/volkszaehler/volkszaehler.org/blob/master/lib/Definition/EntityDefinition.json
+EntityType = Literal[
+    "group",
+    "building",
+    "user",
+    "power",
+    "powersensor",
+    "electric meter",
+    "voltage",
+    "current",
+    "gas",
+    "gas sensor",
+    "gas meter",
+    "heat",
+    "heatsensor",
+    "heattotal",
+    "temperature",
+    "water",
+    "flow",
+    "watertotal",
+    "filllevel",
+    "workinghours",
+    "workinghourstotal",
+    "workinghourssensor",
+    "valve",
+    "pressure",
+    "humidity",
+    "humidity absolute",
+    "windspeed",
+    "fanspeed",
+    "luminosity",
+    "illumination",
+    "frequency",
+    "universalcounter",
+    "universalsensor",
+    "consumptionsensor",
+    "virtualsensor",
+    "virtualconsumption",
+    "co2 concentration",
+    "particulate matter",
+]
+
+
+class Entity(TypedDict, total=False):
+    """Typed representation of a Volkszaehler entity."""
+
+    uuid: str
+    type: EntityType
+    color: str
+    fillstyle: int
+    linestyle: str
+    public: bool
+    resolution: int
+    style: str
+    title: str
+    yaxis: str


### PR DESCRIPTION
First step to allow the Volkszaehler home assistant integration to pull all available Channels. 

Idea from @erwindouna https://github.com/home-assistant/core/pull/169500#discussion_r3257300195